### PR TITLE
Release 2.0.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Changelog
 ==================
 * Removed ``base.html`` for performance reasons
 * Fixed faulty settings parsing in aldryn_config.py
+* Fixed an issue where ValidationError wasn't imported
 * Adapted private ``get_template`` method
 * Updated translations
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Changelog
 =========
 
 
-2.0.1 (unreleased)
+2.0.1 (2016-09-08)
 ==================
 * Removed ``base.html`` for performance reasons
 * Fixed faulty settings parsing in aldryn_config.py

--- a/djangocms_video/__init__.py
+++ b/djangocms_video/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '2.0.0'
+__version__ = '2.0.1'

--- a/djangocms_video/models.py
+++ b/djangocms_video/models.py
@@ -6,6 +6,7 @@ sources to be displayed in an HTML5 player.
 """
 from django.db import models
 from django.conf import settings
+from django.core.exceptions import ValidationError
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext, ugettext_lazy as _
 


### PR DESCRIPTION
* Removed ``base.html`` for performance reasons
* Fixed faulty settings parsing in aldryn_config.py
* Adapted private ``get_template`` method
* Updated translations