### PR TITLE
Fix swappable filer image model support

### DIFF
--- a/djangocms_video/migrations/0003_field_adaptions.py
+++ b/djangocms_video/migrations/0003_field_adaptions.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+from django.conf import settings
 from django.db import migrations, models
 import filer.fields.image
 import django.db.models.deletion
@@ -10,6 +11,7 @@ import djangocms_attributes_field.fields
 class Migration(migrations.Migration):
 
     dependencies = [
+        migrations.swappable_dependency(settings.FILER_IMAGE_MODEL),
         ('djangocms_video', '0002_set_related_name_for_cmsplugin_ptr'),
     ]
 
@@ -31,7 +33,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='videoplayer',
             name='poster',
-            field=filer.fields.image.FilerImageField(related_name='+', on_delete=django.db.models.deletion.SET_NULL, verbose_name='Poster', blank=True, to='filer.Image', null=True),
+            field=filer.fields.image.FilerImageField(related_name='+', on_delete=django.db.models.deletion.SET_NULL, verbose_name='Poster', blank=True, to=settings.FILER_IMAGE_MODEL, null=True),
         ),
         migrations.AddField(
             model_name='videoplayer',

--- a/djangocms_video/migrations/0005_migrate_to_filer.py
+++ b/djangocms_video/migrations/0005_migrate_to_filer.py
@@ -1,12 +1,15 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+from django.conf import settings
 from django.db import migrations, models
 
 
 def migrate_to_filer(apps, schema_editor):
     # Because filer is polymorphic, Djangos migration can't handle
-    from filer.models import Image
+    from filer.utils.loader import load_model
+
+    Image = load_model(settings.FILER_IMAGE_MODEL)
     VideoPlayer = apps.get_model('djangocms_video', 'VideoPlayer')
     plugins = VideoPlayer.objects.all()
 
@@ -24,7 +27,7 @@ def migrate_to_filer(apps, schema_editor):
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('filer', '0002_auto_20150606_2003'),
+        migrations.swappable_dependency(settings.FILER_IMAGE_MODEL),
         ('djangocms_video', '0004_move_to_attributes'),
     ]
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from djangocms_video import __version__
 
 REQUIREMENTS = [
     'django-cms>=3.3.1',
-    'django-filer>=1.2.4',
+    'django-filer>=1.3.0',
     'djangocms-attributes-field>=0.1.1',
 ]
 


### PR DESCRIPTION
As of filer 1.3.0, proper swappable image model support is available. This PR makes it possible to use djangocms-video with swapped image model.