### PR TITLE
Add support for configurable youtube embed URL

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,12 @@ Changelog
 =========
 
 
+2.x.x
+=====
+
+* Added setting DJANGOCMS_VIDEO_YOUTUBE_EMBED_URL to allow overriding the default canonical YouTube URL
+
+
 2.3.0 (2020-01-29)
 ==================
 

--- a/README.rst
+++ b/README.rst
@@ -82,6 +82,13 @@ the default setting by overriding::
 
     DJANGOCMS_VIDEO_ALLOWED_EXTENSIONS = ['mp4', 'webm', 'ogv']
 
+The plugin detects YouTube URLs using a regular expression and canonicalizes
+them to `//www.youtube.com/embed/{}` where the placeholder is replaced by the
+video id.
+
+The canonical URL can be reconfigured with a configuration setting::
+
+    DJANGOCMS_VIDEO_YOUTUBE_EMBED_URL = '//www.youtube-nocookie.com/embed/{}'
 
 Running Tests
 -------------

--- a/djangocms_video/forms.py
+++ b/djangocms_video/forms.py
@@ -2,6 +2,7 @@
 import re
 
 from django import forms
+from django.conf import settings
 
 from . import models
 
@@ -9,7 +10,7 @@ from . import models
 YOUTUBE_URL_RE = re.compile(r'(?:(?:http://|https://|//)?(?:www\.)?youtu\.?be.*).*')
 # https://stackoverflow.com/a/9102270
 YOUTUBE_VIDEO_ID_RE = re.compile(r'(?:[?&]v=|/embed/|/1/|/v/|https?://(?:www\.)?youtu\.be/)([^&\n?#]+)')
-YOUTUBE_EMBED_URL = '//www.youtube.com/embed/{}'
+DEFAULT_YOUTUBE_EMBED_URL = '//www.youtube.com/embed/{}'
 
 
 class VideoPlayerPluginForm(forms.ModelForm):
@@ -25,5 +26,6 @@ class VideoPlayerPluginForm(forms.ModelForm):
             # try to get the video id
             results = YOUTUBE_VIDEO_ID_RE.findall(link)
             if results:
-                link = YOUTUBE_EMBED_URL.format(results[0])
+                embed_url = getattr(settings, "DJANGOCMS_VIDEO_YOUTUBE_EMBED_URL", DEFAULT_YOUTUBE_EMBED_URL)
+                link = embed_url.format(results[0])
         return link


### PR DESCRIPTION
The rationale for this change is a requirement to embed videos in a GDPR
compliant manner. We try to avoid ugly cookie permit banners by reducing
cookies to the technically required minimum.

This commit adds a new optional setting
DJANGOCMS_VIDEO_YOUTUBE_EMBED_URL which defaults to the original value
of YOUTUBE_EMBED_URL. The tests.test_forms.VideoFormTestCase class has
been modified to test the original variations as well es new URL
variations using the youtube-nocookie.com domain.

Signed-off-by: Jan Dittberner <jan.dittberner@t-systems.com>